### PR TITLE
schema update for SeasonID and golang index types

### DIFF
--- a/schema/episodes.cue
+++ b/schema/episodes.cue
@@ -24,7 +24,7 @@ package schema
 
 // Unique identifier for an episode.
 #MatchID: {
-  season?: #SeasonID
+  season?: #SeasonName
   match: #MatchNumber
   show_title?: string
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -157,7 +157,6 @@ type BoardPosition struct {
 }
 
 type BoardSelection struct {
-	ContestantID      `json:",inline"`
 	ChallengeMetadata `json:",inline"`
 	BoardPosition     `json:",inline"`
 }
@@ -174,11 +173,11 @@ type SelectionOutcome struct {
 
 type CategoryName string
 
-type CategoryIndex map[CategoryName]CategoryAired
+type CategoryIndex map[CategoryName]*CategoryAired
 
 type CategoryMetadata struct {
-	CategoryName `json:"title"`
-	CategoryID   uint64 `json:"catID"`
+	Name       CategoryName `json:"title"`
+	CategoryID uint64       `json:"catID"`
 }
 
 type Category struct {
@@ -191,7 +190,8 @@ type Category struct {
 
 type CategoryAired struct {
 	CategoryMetadata `json:",inline"`
-	Aired            ShowDate `json:"aired"`
+
+	Aired ShowDate `json:"aired"`
 }
 
 type CategoryThemeEnum int
@@ -211,19 +211,20 @@ const (
  * EPISODES
  */
 
-// Shows are numbered sequentially based on air date.
-// These are historic contests obtained piecemeal from jarchive.com
-type MatchID struct {
-	Season    SeasonID    `json:"season,omitempty"`
-	Match     MatchNumber `json:"match"`
-	ShowTitle string      `json:"show_title,omitempty"`
-}
-
 // A match identifier refers to the unique identifier of the ?-Party database.
 // These are not universally unique, they are only certain to be locally unique.
 type MatchNumber uint64
 
-type EpisodeIndex map[MatchNumber]EpisodeMetadata
+// Shows are numbered sequentially based on air date.
+// These are historic contests obtained piecemeal from jarchive.com
+type MatchID struct {
+	Match MatchNumber `json:"match"`
+
+	SeasonStub string `json:"season,omitempty"`
+	ShowTitle  string `json:"show_title,omitempty"`
+}
+
+type EpisodeIndex map[MatchNumber]*EpisodeMetadata
 
 type EpisodeMetadata struct {
 	MatchID   `json:",inline"`
@@ -293,20 +294,19 @@ type Career struct {
  * SEASONS
  */
 
-type SeasonID string
+type SeasonStub string
 
-type SeasonIndex struct {
-	SemVer  []uint                      `json:"version"`
-	Seasons map[SeasonID]SeasonMetadata `json:"seasons"`
+type SeasonID struct {
+	Stub  SeasonStub `json:"stub"`
+	Title string     `json:"title"`
 }
 
+type SeasonIndex map[SeasonStub]*SeasonMetadata
+
 type SeasonMetadata struct {
-	Season SeasonID `json:"season"`
-	Name   string   `json:"name"`
-	Aired  struct {
-		From  ShowDate `json:"from"`
-		Until ShowDate `json:"until"`
-	}
+	Season SeasonID      `json:"season"`
+	Title  string        `json:"title,omitempty"`
+	Aired  ShowDateRange `json:"aired,omitempty"`
 
 	EpisodeCount   int `json:"episode_count,omitempty"`
 	ChallengeCount int `json:"challenge_count,omitempty"`

--- a/schema/seasons.cue
+++ b/schema/seasons.cue
@@ -23,18 +23,18 @@
 package schema
 
 // Unique identifier for the season and its episodes.
-#SeasonID: string
+#SeasonName: string
 
 // Schema for [seasons.json] containing season and episode metadata.
 #SeasonIndex: {
   version?: [...uint]
-  seasons: [#SeasonID]: #SeasonMetadata
+  seasons: [#SeasonName]: #SeasonMetadata
 }
 
 // Metadata for a single season, has identity and some statistics.
 #SeasonMetadata: {
-  season: #SeasonID
-  name: string
+  season: #SeasonName
+  title: string
   aired: #ShowDateRange
 
   episode_count?:   *0 | int & >=0

--- a/selfhost/go.mod
+++ b/selfhost/go.mod
@@ -4,7 +4,4 @@ go 1.23.4
 
 replace github.com/kevindamm/q-party/schema => ../schema
 
-require (
-	github.com/kevindamm/q-party/schema v0.0.0-00010101000000-000000000000
-	golang.org/x/net v0.38.0
-)
+require github.com/kevindamm/q-party/schema v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
reference types used in golang index types (SeasonIndex, EpisodeIndex, CategoryIndex) which makes the zero value easier to case-match out and makes the index itself more compact and faster to write (the indirection makes reading a little bit slower, but the ease of updates helps with merge operations, especially when assisted by a proper Merge function on each of these index types)

SeasonID is now a structured type with both stub and title components