### PR TITLE
substitute zod + chanfana deps for @zod/mini

### DIFF
--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -8,9 +8,9 @@
 			"name": "q-party-server",
 			"version": "0.0.2",
 			"dependencies": {
+				"@zod/mini": "^4.0.0-beta.0",
 				"chanfana": "^2.7.2",
-				"hono": "^4.7.5",
-				"zod": "^3.24.2"
+				"hono": "^4.7.5"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20250320.0",
@@ -1027,6 +1027,27 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.20.0"
+			}
+		},
+		"node_modules/@zod/core": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@zod/core/-/core-0.1.0.tgz",
+			"integrity": "sha512-hSXsufqjH7u8DiJPT0KY1rFWIhjkdXGM8MhMLwzaeOMhxMA4bzjWLQwSoAToJunUTVrpmfdo4dUFzNaU219+VQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@zod/mini": {
+			"version": "4.0.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@zod/mini/-/mini-4.0.0-beta.0.tgz",
+			"integrity": "sha512-ux1pJYQJO0S/uAldc0KGKiBFvqPpQqfC8vXbBJ3tDrcWCCa6/QBQPexZFn/cHscTxA/SnEJEAxa7qGTwPQC5Tg==",
+			"license": "MIT",
+			"dependencies": {
+				"@zod/core": "0.1.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/acorn": {

--- a/workers/package.json
+++ b/workers/package.json
@@ -7,9 +7,8 @@
 		"deploy": "wrangler deploy --minify"
 	},
 	"dependencies": {
-		"chanfana": "^2.7.2",
-		"hono": "^4.7.5",
-		"zod": "^3.24.2"
+		"@zod/mini": "^4.0.0-beta.0",
+		"hono": "^4.7.5"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250320.0",


### PR DESCRIPTION
remove chanfana from deps, add @zod/mini in place of Zod 3

reasoning:
  * I don't really need to publish an API, let alone an OpenAPI type definition, for the client/server player interactions.  It might make it easier to plug in an LLM but .. most of the complexity is in the websocket protocol anyway.
  * @zod/mini packs down to a very nice library size
  * @zod/mini has some of the improvements coming in Zod 4 (@zod/next), still in beta
  * I'm not sure if chanfana will play nicely with zod-mini yet.  It probably makes some imports from zod which would need to be patched.  I don't need it enough, so it's out.