### PR TITLE
pull fetcher/fetchable up into parent directory, and some improvements

### DIFF
--- a/selfhost/cmd/fetch/fetchable.go
+++ b/selfhost/cmd/fetch/fetchable.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 Kevin Damm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// github:kevindamm/q-party/cmd/fetch/jarchive/fetchable.go
+
+package fetch
+
+import "io"
+
+type Fetchable interface {
+	// Descriptive string used only in debugging / log output.
+	String() string
+
+	// The remote URL where this resource can be fetched.
+	URL() string
+	// A local file path (relative to datapath) where the HTML source is mirrored.
+	FilepathHTML() string
+	// A local file path (relative to datapath) where the JSON source is stored.
+	FilepathJSON() string
+
+	// Converts the resource from its HTML representation
+	// into the properties of the current Fetchable instance.
+	ParseHTML([]byte) error
+
+	// Writes the JSON-formatted resource to the provided writer, and closes it.
+	WriteJSON(io.WriteCloser) error
+
+	// Loads the resource from the provided reader, and closes the reader.
+	// Assumes the reader is providing JSON-formatted bytes.
+	LoadJSON(io.ReadCloser) error
+}

--- a/selfhost/cmd/fetch/jarchive/episodes.go
+++ b/selfhost/cmd/fetch/jarchive/episodes.go
@@ -23,7 +23,12 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"path"
+
 	"github.com/kevindamm/q-party/schema"
+	"github.com/kevindamm/q-party/selfhost/cmd/fetch"
 )
 
 type EpisodeID int
@@ -32,21 +37,72 @@ type EpisodeMatchNumber map[EpisodeID]schema.MatchNumber
 type MatchNumberEpisode map[schema.MatchNumber]EpisodeID
 
 // All details of the episode, including correct answers & the contestants' bios.
-type JarchiveEpisode struct {
-	schema.EpisodeMetadata `json:",inline"`
-	Comments               string            `json:"comments,omitempty"`
-	Media                  []schema.MediaRef `json:"media,omitempty"`
+type JarchiveEpisode interface {
+	fetch.Fetchable
+}
 
-	// Due to absence of archival evidence, not every episode has both single & double rounds.
+func NewEpisode(id EpisodeID) JarchiveEpisode {
+	episode := episode{
+		EpisodeID: id,
+	}
+
+	// TODO
+	return &episode
+}
+
+type episode struct {
+	schema.EpisodeMetadata `json:",inline"`
+
+	EpisodeID EpisodeID         `json:"episode_id,omitempty"`
+	Comments  string            `json:"comments,omitempty"`
+	Media     []schema.MediaRef `json:"media,omitempty"`
+
+	// Due to absence of archival evidence,
+	// not every episode has both single & double rounds.
 	Single     *JarchiveBoard `json:"single,omitempty"`
 	Double     *JarchiveBoard `json:"double,omitempty"`
 	Final      *JarchiveFinal `json:"final,omitempty"`
 	TieBreaker *JarchiveFinal `json:"tiebreaker,omitempty"`
 }
 
-func ParseEpisodeHtml(episode_html []byte) (*JarchiveEpisode, error) {
-	episode := JarchiveEpisode{}
+func ParseEpisodeHtml(episode_html []byte) (JarchiveEpisode, error) {
+	episode := episode{}
 	// TODO
 
 	return &episode, nil
+}
+
+func (episode *episode) String() string {
+	// TODO
+	return "episode ..."
+}
+
+func (episode *episode) URL() string {
+	const FULL_EPISODE_FMT = "https://j-archive.com/showgame.php?game_id=%d"
+	return fmt.Sprintf(FULL_EPISODE_FMT, episode.EpisodeID)
+}
+
+func (episode *episode) FilepathHTML() string {
+	return path.Join("episode", fmt.Sprintf("%d.html", episode.EpisodeID))
+}
+
+func (episode *episode) FilepathJSON() string {
+	return path.Join("json", "episode", fmt.Sprintf("%d.html", episode.MatchID))
+}
+
+func (episode *episode) ParseHTML(html_bytes []byte) error {
+
+	// TODO
+	return nil
+}
+
+func (episode *episode) WriteJSON(output io.WriteCloser) error {
+	defer output.Close()
+	// TODO
+	return nil
+}
+func (episode *episode) LoadJSON(input io.ReadCloser) error {
+	defer input.Close()
+	// TODO
+	return nil
 }

--- a/selfhost/cmd/fetch/jarchive/index.go
+++ b/selfhost/cmd/fetch/jarchive/index.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 
 	"github.com/kevindamm/q-party/schema"
+	"github.com/kevindamm/q-party/selfhost/cmd/fetch"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -158,12 +159,46 @@ func (index *index) WriteJSONLines(writer io.Writer) error {
 
 // Internal representation of [JarchiveIndex] with safe read and update access.
 type index struct {
+	fetch.Fetchable
 	SemVer     []int                `json:"version"`
 	Seasons    schema.SeasonIndex   `json:"seasons"`
 	Episodes   schema.EpisodeIndex  `json:"episodes"`
 	Categories schema.CategoryIndex `json:"categories"`
 
 	lock sync.RWMutex `json:"-"`
+}
+
+func (index *index) String() string {
+	return "(top-level index)"
+}
+
+func (index *index) URL() string {
+	return "https://j-archive.com/listseasons.php"
+}
+
+func (index *index) FilepathHtml() string {
+	return "index.html"
+}
+
+func (index *index) FilepathJSON() string {
+	return "jarchive.jsonl"
+}
+
+func (index *index) ParseHtml(html_bytes []byte) error {
+	// TODO
+	return nil
+}
+
+func (index *index) WriteJSON(writer io.WriteCloser) error {
+	defer writer.Close()
+	// TODO
+	return nil
+}
+
+func (index *index) LoadJSON(reader io.ReadCloser) error {
+	defer reader.Close()
+	// TODO
+	return nil
 }
 
 func (index *index) Version() []int {


### PR DESCRIPTION
…en fetching trivia from OSTDB and any other willing sources

Fetcher has been further generalized to any interface-compatible "Fetchable" which can provide its URL (and local file paths) as well as parse the contents of a byte slice (formatted as HTML) or read/write its JSON representation

some functions are still TBD but Fetcher is well defined now

follow-up PR will improve Fetcher to look for an already-existing HTML file, and fetch only if needed.  The JSON conversion will always happen, at least while the parse and massage process is being improved (or provided, in the case of episodes, which is done but not yet integrated into this version of the code organization)