### PR TITLE
fetchable implementation of top-level index

### DIFF
--- a/schema/match.cue
+++ b/schema/match.cue
@@ -35,8 +35,6 @@ package schema
 
 // Identifiers and statistics for each episode.
 #EpisodeMetadata: #MatchID & {
-  jaid?: uint
-
   aired?: #ShowDate
   taped?: #ShowDate
 

--- a/schema/match.go
+++ b/schema/match.go
@@ -51,8 +51,6 @@ func NewMatchID(match_number int) MatchID {
 
 type EpisodeMetadata struct {
 	MatchID   `json:",inline"`
-	EpisodeID uint `json:"jaid,omitempty"`
-
 	AiredDate ShowDate `json:"aired,omitempty"`
 	TapedDate ShowDate `json:"taped,omitempty"`
 
@@ -79,9 +77,6 @@ func (episodes EpisodeIndex) Update(metadata EpisodeMetadata) {
 		existing.ShowTitle = metadata.ShowTitle
 	}
 
-	if metadata.EpisodeID != 0 {
-		existing.EpisodeID = metadata.EpisodeID
-	}
 	if metadata.AiredDate.String() != "" {
 		existing.AiredDate = metadata.AiredDate
 	}
@@ -129,7 +124,40 @@ func (sd ShowDate) String() string {
 	return fmt.Sprintf("%04d/%02d/%02d", sd.Year, sd.Month, sd.Day)
 }
 
+// Returns 0 if `this` and `other` are equal;
+// +1 if this is later than other, and -1 if before.
+func (this ShowDate) Compare(other ShowDate) int {
+	if this.Year < other.Year {
+		return -1
+	}
+	if this.Year > other.Year {
+		return +1
+	}
+	// (this.Year == other.Year)
+	if this.Month < other.Month {
+		return -1
+	}
+	if this.Month > other.Month {
+		return +1
+	}
+	// (this.Month == other.Month)
+	if this.Day < other.Day {
+		return -1
+	}
+	if this.Day > other.Day {
+		return +1
+	}
+	// The dates are equal.
+	return 0
+}
+
 type ShowDateRange struct {
 	From  ShowDate `json:"from,omitempty"`
 	Until ShowDate `json:"until,omitempty"`
+}
+
+func (scope ShowDateRange) Contains(date ShowDate) bool {
+	return (                         // including endpoints,
+	date.Compare(scope.From) >= 0 && // after beginning and
+		date.Compare(scope.Until) <= 0) // before ending
 }

--- a/schema/match_test.go
+++ b/schema/match_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 Kevin Damm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// github:kevindamm/q-party/schema/matches.go
+
+package schema_test
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/kevindamm/q-party/schema"
+)
+
+func TestDateCompare(t *testing.T) {
+	tests := []struct {
+		name  string
+		this  schema.ShowDate
+		other schema.ShowDate
+		want  int
+	}{
+		{"less-than",
+			schema.ShowDate{Year: 2000, Month: 9, Day: 1},
+			schema.ShowDate{Year: 2001, Month: 9, Day: 1},
+			-1},
+		{"greater-than",
+			schema.ShowDate{Year: 2002, Month: 9, Day: 2},
+			schema.ShowDate{Year: 2001, Month: 9, Day: 2},
+			1},
+		{"less-than",
+			schema.ShowDate{Year: 1999, Month: 7, Day: 2},
+			schema.ShowDate{Year: 1999, Month: 9, Day: 1},
+			-1},
+		{"greater-than",
+			schema.ShowDate{Year: 2025, Month: 10, Day: 2},
+			schema.ShowDate{Year: 2025, Month: 9, Day: 3},
+			1},
+		{"less-than",
+			schema.ShowDate{Year: 2001, Month: 9, Day: 1},
+			schema.ShowDate{Year: 2001, Month: 9, Day: 2},
+			-1},
+		{"greater-than",
+			schema.ShowDate{Year: 2001, Month: 9, Day: 3},
+			schema.ShowDate{Year: 2001, Month: 9, Day: 2},
+			1},
+		{"equal",
+			schema.ShowDate{Year: 1999, Month: 12, Day: 19},
+			schema.ShowDate{Year: 1999, Month: 12, Day: 19},
+			0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.this.Compare(tt.other); got != tt.want {
+				t.Errorf("ShowDate.Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDateRangeContains(t *testing.T) {
+	scope := schema.ShowDateRange{
+		From:  schema.ShowDate{Year: 1995, Month: 3, Day: 25},
+		Until: schema.ShowDate{Year: 1997, Month: 6, Day: 2},
+	}
+	tests := []struct {
+		name  string
+		scope schema.ShowDateRange
+		date  schema.ShowDate
+		want  bool
+	}{
+		{"before", scope,
+			schema.ShowDate{Year: 1979, Month: 1, Day: 13},
+			false},
+		{"after", scope,
+			schema.ShowDate{Year: 2000, Month: 1, Day: 1},
+			false},
+		{"within", scope,
+			schema.ShowDate{Year: 1996, Month: 10, Day: 31},
+			true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.scope.Contains(tt.date); got != tt.want {
+				t.Errorf("ShowDateRange.Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/schema/season.cue
+++ b/schema/season.cue
@@ -38,9 +38,10 @@ package schema
 #SeasonMetadata: #SeasonName & {
   aired: #ShowDateRange
 
-  episode_count?:   *0 | int & >=0
-  challenge_count?: *0 | int & >=0
-  tripstump_count?: *0 | int & >=0
+  episode_count?:   *0 | int & >0
+  category_count?:  *0 | int & >0
+  challenge_count?: *0 | int & >0
+  tripstump_count?: *0 | int & >0
   ...
 }
 

--- a/schema/season.go
+++ b/schema/season.go
@@ -37,10 +37,11 @@ type SeasonID struct {
 type SeasonIndex map[SeasonSlug]*SeasonMetadata
 
 type SeasonMetadata struct {
-	Season SeasonID      `json:",inline"`
-	Aired  ShowDateRange `json:"aired,omitempty"`
+	SeasonID `json:",inline"`
+	Aired    ShowDateRange `json:"aired,omitempty"`
 
 	EpisodeCount   int `json:"episode_count,omitempty"`
+	CategoryCount  int `json:"category_count,omitempty"`
 	ChallengeCount int `json:"challenge_count,omitempty"`
 	TripStumpCount int `json:"tripstump_count,omitempty"`
 }

--- a/selfhost/cmd/fetch/fetchable.go
+++ b/selfhost/cmd/fetch/fetchable.go
@@ -18,12 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// github:kevindamm/q-party/cmd/fetch/jarchive/fetchable.go
+// github:kevindamm/q-party/cmd/fetch/fetchable.go
 
 package fetch
 
 import "io"
 
+// Abstraction over resources that can be fetched from a remote URL path, cached
+// locally (indefinitely) and parsed from its HTML and JSON representations.  It
+// facilitates the ability to call `fetcher.Fetch(MyResource)` by defining these
+// functions that Fetcher can use as continuations when the resource is fetched.
 type Fetchable interface {
 	// Descriptive string used only in debugging / log output.
 	String() string

--- a/selfhost/cmd/fetch/jarchive/episodes.go
+++ b/selfhost/cmd/fetch/jarchive/episodes.go
@@ -25,6 +25,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"path"
 
 	"github.com/kevindamm/q-party/schema"
@@ -33,21 +34,27 @@ import (
 
 type EpisodeID int
 
-type EpisodeMatchNumber map[EpisodeID]schema.MatchNumber
-type MatchNumberEpisode map[schema.MatchNumber]EpisodeID
-
 // All details of the episode, including correct answers & the contestants' bios.
 type JarchiveEpisode interface {
 	fetch.Fetchable
+	// Properties are set via ParseHTML or LoadJSON (of Fetchable interface)
+
+	// Property getters
+	MatchNumber() schema.MatchNumber // may be 0 for unknown
+
 }
 
 func NewEpisode(id EpisodeID) JarchiveEpisode {
-	episode := episode{
+	if id == 0 {
+		log.Fatal("zero value invalid for episode ID (equiv to UNKNOWN episode)")
+	}
+	return &episode{
 		EpisodeID: id,
 	}
+}
 
-	// TODO
-	return &episode
+func UnknownEpisode() JarchiveEpisode {
+	return &episode{EpisodeID: 0}
 }
 
 type episode struct {
@@ -65,16 +72,14 @@ type episode struct {
 	TieBreaker *JarchiveFinal `json:"tiebreaker,omitempty"`
 }
 
-func ParseEpisodeHtml(episode_html []byte) (JarchiveEpisode, error) {
-	episode := episode{}
-	// TODO
-
-	return &episode, nil
+func (episode *episode) String() string {
+	return fmt.Sprintf("Match %d (episode #%d)",
+		episode.MatchID.Match,
+		episode.EpisodeID)
 }
 
-func (episode *episode) String() string {
-	// TODO
-	return "episode ..."
+func (episode *episode) MatchNumber() schema.MatchNumber {
+	return episode.MatchID.Match
 }
 
 func (episode *episode) URL() string {
@@ -83,26 +88,29 @@ func (episode *episode) URL() string {
 }
 
 func (episode *episode) FilepathHTML() string {
-	return path.Join("episode", fmt.Sprintf("%d.html", episode.EpisodeID))
+	return path.Join("jarchive", "episode",
+		fmt.Sprintf("%d.html", episode.EpisodeID))
 }
 
 func (episode *episode) FilepathJSON() string {
-	return path.Join("json", "episode", fmt.Sprintf("%d.html", episode.MatchID))
+	return path.Join("json", "episode",
+		fmt.Sprintf("%d.html", episode.MatchID.Match))
 }
 
 func (episode *episode) ParseHTML(html_bytes []byte) error {
-
 	// TODO
+	// TODO
+	// TODO populate this instance with parsed contents
 	return nil
 }
 
 func (episode *episode) WriteJSON(output io.WriteCloser) error {
 	defer output.Close()
-	// TODO
+	// TODO json.Unmarshal
 	return nil
 }
 func (episode *episode) LoadJSON(input io.ReadCloser) error {
 	defer input.Close()
-	// TODO
+	// TODO json.Marshal
 	return nil
 }

--- a/selfhost/cmd/fetch/jarchive/index_test.go
+++ b/selfhost/cmd/fetch/jarchive/index_test.go
@@ -37,7 +37,8 @@ var JARCHIVE_INDEX_HTML []byte
 var TEST_VERSION = []int{0, 0, 0}
 
 func TestParseIndexHTML(t *testing.T) {
-	jarchive_index, err := jarchive.ParseIndexHtml(JARCHIVE_INDEX_HTML)
+	jarchive_index := jarchive.NewJarchiveIndex()
+	err := jarchive_index.ParseHTML(JARCHIVE_INDEX_HTML)
 	if err != nil {
 		t.Error("Failed to parse jarchive index:", err)
 		return
@@ -65,7 +66,7 @@ func TestParseIndexHTML(t *testing.T) {
 	}
 
 	for _, slug := range jarchive_index.GetSeasonList() {
-		season := jarchive_index.GetSeasonInfo(slug)
+		season := jarchive_index.GetSeasonMetadata(slug)
 		if season.Aired.From.Year == 0 ||
 			season.Aired.From.Month == 0 ||
 			season.Aired.From.Day == 0 {

--- a/selfhost/cmd/fetch/jarchive/main.go
+++ b/selfhost/cmd/fetch/jarchive/main.go
@@ -60,7 +60,7 @@ func main() {
 	if *data_path == "" {
 		*data_path = "."
 	}
-	jarchive, err := LoadLocalIndex(*data_path) // loads jarchive.jsonl and supporting seasons, episodes
+	jarchive, err := LoadJarchiveJSONL(*data_path) // loads jarchive.jsonl and supporting seasons, episodes
 	if err != nil {
 		debug.Fatal(err)
 	}

--- a/selfhost/cmd/fetch/jarchive/testdata/jarchive_index.html
+++ b/selfhost/cmd/fetch/jarchive/testdata/jarchive_index.html
@@ -12,6 +12,7 @@
   <tr><td><a href="showseason.php?season=27">Season 27</a></td><td class="left_padded">2010-09-13 to 2011-07-29</td><td align="right" class="left_padded">(230 games archived)</td><td class="left_padded"></td></tr>
   <tr><td><a href="showseason.php?season=superjeopardy"><i>Super Jeopardy!</i></a></td><td class="left_padded">1990-06-16 to 1990-09-08</td><td class="left_padded">(13 games archived)</td></tr>
   <tr><td><a href="showseason.php?season=26">Season 26</a></td><td class="left_padded">2009-09-14 to 2010-07-30</td><td align="right" class="left_padded">(230 games archived)</td><td class="left_padded"></td></tr>
+  <tr><td><a href="showseason.php?season=trebekpilots">Trebek pilots</a></td><td class="left_padded">1983-09-18 and 1984?</td><td align="right" class="left_padded">(2 games archived)</td></tr>
   <tr><td><a href="showseason.php?season=23">Season 23</a></td><td class="left_padded">2006-09-11 to 2007-07-27</td><td align="right" class="left_padded">(230 games archived)</td><td class="left_padded"></td></tr>
   <tr><td><a href="showseason.php?season=bbab">Battle of the Bay Area Brains</a></td><td class="left_padded">1998-05-03 to 1998-05-03</td><td class="left_padded">(1 game archived)</td></tr>
 </table>


### PR DESCRIPTION
fleshes out the rest of the structure from the previous PR, adds some functionality to the /schema lib -- date.Compare and daterange.Contains, and a new aggregate on the season metadata (unique category count)